### PR TITLE
Expand server with categories and lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# Estoque-e-Lista-de-Compras
+# FamilyStock Prototype
+
+This repository contains a lightweight prototype of **FamilyStock**, an application for managing household stock and shopping lists. It uses only Node.js core modules and persists data in a JSON file (`data.json`).
+
+## Executando
+
+1. Instale Node.js (versão 14 ou superior).
+2. Na raiz do projeto execute:
+
+```bash
+node server.js
+```
+
+3. Acesse `http://localhost:3000` no navegador para utilizar a interface simples.
+
+## Principais rotas da API
+
+- `POST /api/users` – cria usuário `{ name, email, password }`
+- `POST /api/login` – autentica usuário `{ email, password }`
+- `POST /api/families` – cria família `{ name, userId }`
+- `POST /api/families/:id/join` – usuário entra em família `{ userId }`
+- `GET /api/families/:id/categories` – lista categorias
+- `POST /api/families/:id/categories` – cria categoria `{ name }`
+- `GET /api/families/:id/products` – lista produtos
+- `POST /api/families/:id/products` – adiciona produto `{ name, quantity, minimum, unit, categoryId?, userId }`
+- `PUT /api/families/:fid/products/:pid` – atualiza produto
+- `DELETE /api/families/:fid/products/:pid` – remove produto
+- `GET /api/families/:id/shopping-lists` – lista listas de compras
+- `POST /api/families/:id/shopping-lists` – cria lista manual `{ name, items }`
+- `POST /api/families/:id/shopping-lists/auto` – gera lista automática de itens em falta
+
+Todos os dados são mantidos em memória e salvos em `data.json` a cada alteração.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+const DATA_FILE = 'data.json';
+const defaultDb = {
+  users: [],
+  families: [],
+  familyMembers: [],
+  categories: [],
+  products: [],
+  shoppingLists: []
+};
+
+let db = { ...defaultDb };
+
+if (fs.existsSync(DATA_FILE)) {
+  try {
+    db = JSON.parse(fs.readFileSync(DATA_FILE));
+  } catch (e) {
+    console.error('Failed to load DB, using defaults', e);
+  }
+}
+
+function save() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(db, null, 2));
+}
+
+function generateId(prefix = '') {
+  return prefix + Math.random().toString(36).substr(2, 9);
+}
+
+module.exports = { db, save, generateId };

--- a/index.html
+++ b/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>FamilyStock MVP</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    section { margin-bottom: 2em; }
+    form label { display: block; margin-top: 0.5em; }
+  </style>
+</head>
+<body>
+<h1>FamilyStock MVP</h1>
+
+<section id="auth">
+  <h2>Register</h2>
+  <form id="register-form">
+    <label>Name <input type="text" id="reg-name" required></label>
+    <label>Email <input type="email" id="reg-email" required></label>
+    <label>Password <input type="password" id="reg-password" required></label>
+    <button type="submit">Register</button>
+  </form>
+  <h2>Login</h2>
+  <form id="login-form">
+    <label>Email <input type="email" id="log-email" required></label>
+    <label>Password <input type="password" id="log-password" required></label>
+    <button type="submit">Login</button>
+  </form>
+</section>
+
+<section id="family" style="display:none">
+  <h2>Create Family</h2>
+  <form id="family-form">
+    <label>Name <input type="text" id="family-name" required></label>
+    <button type="submit">Create</button>
+  </form>
+</section>
+
+<section id="app" style="display:none">
+  <h2>Categories</h2>
+  <form id="cat-form">
+    <label>Name <input type="text" id="cat-name" required></label>
+    <button type="submit">Add Category</button>
+  </form>
+  <ul id="cat-list"></ul>
+
+  <h2>Products</h2>
+  <form id="product-form">
+    <label>Name <input type="text" id="prod-name" required></label>
+    <label>Quantity <input type="number" id="prod-quantity" value="1" step="0.01" required></label>
+    <label>Minimum <input type="number" id="prod-minimum" value="1" step="0.01" required></label>
+    <label>Unit <input type="text" id="prod-unit" value="unit" required></label>
+    <label>Category
+      <select id="prod-category"></select>
+    </label>
+    <button type="submit">Add Product</button>
+  </form>
+  <ul id="product-list"></ul>
+
+  <h2>Auto Shopping List</h2>
+  <button id="generate-btn">Generate</button>
+  <ul id="list-items"></ul>
+</section>
+
+<script>
+let userId = localStorage.getItem('userId');
+let familyId = localStorage.getItem('familyId');
+
+function show(id, visible) {
+  document.getElementById(id).style.display = visible ? '' : 'none';
+}
+
+function updateView() {
+  show('auth', !userId);
+  show('family', userId && !familyId);
+  show('app', userId && familyId);
+  if (familyId) {
+    loadCategories();
+    loadProducts();
+    loadLists();
+  }
+}
+
+async function register(e) {
+  e.preventDefault();
+  const name = document.getElementById('reg-name').value;
+  const email = document.getElementById('reg-email').value;
+  const password = document.getElementById('reg-password').value;
+  await fetch('/api/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password })
+  });
+  alert('Registered! Please login.');
+  e.target.reset();
+}
+
+async function login(e) {
+  e.preventDefault();
+  const email = document.getElementById('log-email').value;
+  const password = document.getElementById('log-password').value;
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    userId = data.id;
+    localStorage.setItem('userId', userId);
+    updateView();
+  } else {
+    alert('Login failed');
+  }
+}
+
+async function createFamily(e) {
+  e.preventDefault();
+  const name = document.getElementById('family-name').value;
+  const res = await fetch('/api/families', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, userId })
+  });
+  if (res.ok) {
+    const family = await res.json();
+    familyId = family.id;
+    localStorage.setItem('familyId', familyId);
+    updateView();
+  }
+}
+
+async function loadCategories() {
+  const res = await fetch(`/api/families/${familyId}/categories`);
+  const cats = await res.json();
+  const list = document.getElementById('cat-list');
+  const select = document.getElementById('prod-category');
+  list.innerHTML = '';
+  select.innerHTML = '';
+  cats.forEach(c => {
+    const li = document.createElement('li');
+    li.textContent = c.name;
+    list.appendChild(li);
+    const opt = document.createElement('option');
+    opt.value = c.id;
+    opt.textContent = c.name;
+    select.appendChild(opt);
+  });
+}
+
+async function addCategory(e) {
+  e.preventDefault();
+  const name = document.getElementById('cat-name').value;
+  await fetch(`/api/families/${familyId}/categories`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+  e.target.reset();
+  loadCategories();
+}
+
+async function loadProducts() {
+  const res = await fetch(`/api/families/${familyId}/products`);
+  const products = await res.json();
+  const list = document.getElementById('product-list');
+  list.innerHTML = '';
+  products.forEach(p => {
+    const li = document.createElement('li');
+    li.textContent = `${p.name} - ${p.current_quantity}${p.unit}`;
+    list.appendChild(li);
+  });
+}
+
+async function addProduct(e) {
+  e.preventDefault();
+  const name = document.getElementById('prod-name').value;
+  const quantity = document.getElementById('prod-quantity').value;
+  const minimum = document.getElementById('prod-minimum').value;
+  const unit = document.getElementById('prod-unit').value;
+  const categoryId = document.getElementById('prod-category').value;
+  await fetch(`/api/families/${familyId}/products`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, quantity, minimum, unit, categoryId, userId })
+  });
+  e.target.reset();
+  loadProducts();
+}
+
+async function generateList() {
+  const res = await fetch(`/api/families/${familyId}/shopping-lists/auto`, { method: 'POST' });
+  const list = await res.json();
+  const ul = document.getElementById('list-items');
+  ul.innerHTML = '';
+  list.items.forEach(it => {
+    const li = document.createElement('li');
+    li.textContent = `${it.quantity} ${it.unit} - ${it.productId}`;
+    ul.appendChild(li);
+  });
+}
+
+async function loadLists() {
+  const res = await fetch(`/api/families/${familyId}/shopping-lists`);
+  const lists = await res.json();
+  if (lists.length) {
+    const last = lists[lists.length - 1];
+    const ul = document.getElementById('list-items');
+    ul.innerHTML = '';
+    last.items.forEach(it => {
+      const li = document.createElement('li');
+      li.textContent = `${it.quantity} ${it.unit} - ${it.productId}`;
+      ul.appendChild(li);
+    });
+  }
+}
+
+document.getElementById('register-form').addEventListener('submit', register);
+document.getElementById('login-form').addEventListener('submit', login);
+document.getElementById('family-form').addEventListener('submit', createFamily);
+document.getElementById('cat-form').addEventListener('submit', addCategory);
+document.getElementById('product-form').addEventListener('submit', addProduct);
+document.getElementById('generate-btn').addEventListener('click', generateList);
+
+updateView();
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,260 @@
+const http = require('http');
+const url = require('url');
+const fs = require('fs');
+const crypto = require('crypto');
+const { db, save, generateId } = require('./db');
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+function hashPassword(pw) {
+  return crypto.createHash('sha256').update(pw).digest('hex');
+}
+
+const server = http.createServer(async (req, res) => {
+  const { pathname } = url.parse(req.url, true);
+
+  // Serve HTML
+  if (req.method === 'GET' && (pathname === '/' || pathname === '/index.html')) {
+    const html = fs.readFileSync('index.html');
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    return res.end(html);
+  }
+
+  // Register user
+  if (pathname === '/api/users' && req.method === 'POST') {
+    try {
+      const body = await parseBody(req);
+      if (!body.email || !body.password || !body.name) {
+        return sendJson(res, 400, { error: 'Missing fields' });
+      }
+      if (db.users.find(u => u.email === body.email)) {
+        return sendJson(res, 400, { error: 'Email exists' });
+      }
+      const user = {
+        id: generateId('u_'),
+        email: body.email,
+        name: body.name,
+        passwordHash: hashPassword(body.password)
+      };
+      db.users.push(user);
+      save();
+      return sendJson(res, 201, { id: user.id, email: user.email, name: user.name });
+    } catch (e) {
+      return sendJson(res, 400, { error: 'Invalid JSON' });
+    }
+  }
+
+  // Login
+  if (pathname === '/api/login' && req.method === 'POST') {
+    try {
+      const body = await parseBody(req);
+      const user = db.users.find(u => u.email === body.email);
+      if (!user || user.passwordHash !== hashPassword(body.password)) {
+        return sendJson(res, 401, { error: 'Invalid credentials' });
+      }
+      return sendJson(res, 200, { id: user.id, email: user.email, name: user.name });
+    } catch (e) {
+      return sendJson(res, 400, { error: 'Invalid JSON' });
+    }
+  }
+
+  // Create family
+  if (pathname === '/api/families' && req.method === 'POST') {
+    try {
+      const body = await parseBody(req);
+      const user = db.users.find(u => u.id === body.userId);
+      if (!user || !body.name) {
+        return sendJson(res, 400, { error: 'Invalid data' });
+      }
+      const family = { id: generateId('f_'), name: body.name, createdBy: user.id };
+      db.families.push(family);
+      db.familyMembers.push({ familyId: family.id, userId: user.id, role: 'admin' });
+      save();
+      return sendJson(res, 201, family);
+    } catch (e) {
+      return sendJson(res, 400, { error: 'Invalid JSON' });
+    }
+  }
+
+  // Join family
+  const joinMatch = pathname.match(/^\/api\/families\/([^/]+)\/join$/);
+  if (joinMatch && req.method === 'POST') {
+    try {
+      const familyId = joinMatch[1];
+      const body = await parseBody(req);
+      const user = db.users.find(u => u.id === body.userId);
+      const family = db.families.find(f => f.id === familyId);
+      if (!user || !family) {
+        return sendJson(res, 400, { error: 'Invalid data' });
+      }
+      if (!db.familyMembers.find(m => m.familyId === familyId && m.userId === user.id)) {
+        db.familyMembers.push({ familyId, userId: user.id, role: 'member' });
+        save();
+      }
+      return sendJson(res, 200, { joined: true });
+    } catch (e) {
+      return sendJson(res, 400, { error: 'Invalid JSON' });
+    }
+  }
+
+  // Categories
+  const catMatch = pathname.match(/^\/api\/families\/([^/]+)\/categories$/);
+  if (catMatch) {
+    const familyId = catMatch[1];
+    if (req.method === 'GET') {
+      const cats = db.categories.filter(c => c.familyId === familyId);
+      return sendJson(res, 200, cats);
+    }
+    if (req.method === 'POST') {
+      try {
+        const body = await parseBody(req);
+        if (!body.name) {
+          return sendJson(res, 400, { error: 'Missing name' });
+        }
+        const cat = { id: generateId('c_'), familyId, name: body.name };
+        db.categories.push(cat);
+        save();
+        return sendJson(res, 201, cat);
+      } catch (e) {
+        return sendJson(res, 400, { error: 'Invalid JSON' });
+      }
+    }
+  }
+
+  // Products
+  const prodMatch = pathname.match(/^\/api\/families\/([^/]+)\/products$/);
+  if (prodMatch) {
+    const familyId = prodMatch[1];
+    if (req.method === 'GET') {
+      const products = db.products.filter(p => p.familyId === familyId);
+      return sendJson(res, 200, products);
+    }
+    if (req.method === 'POST') {
+      try {
+        const body = await parseBody(req);
+        if (!body.name || body.quantity === undefined || !body.unit || !body.minimum) {
+          return sendJson(res, 400, { error: 'Missing fields' });
+        }
+        const product = {
+          id: generateId('p_'),
+          familyId,
+          categoryId: body.categoryId || null,
+          name: body.name,
+          current_quantity: Number(body.quantity),
+          minimum_quantity: Number(body.minimum),
+          unit: body.unit,
+          created_by: body.userId
+        };
+        db.products.push(product);
+        save();
+        return sendJson(res, 201, product);
+      } catch (e) {
+        return sendJson(res, 400, { error: 'Invalid JSON' });
+      }
+    }
+  }
+
+  // Update/Delete product
+  const prodIdMatch = pathname.match(/^\/api\/families\/([^/]+)\/products\/([^/]+)$/);
+  if (prodIdMatch) {
+    const familyId = prodIdMatch[1];
+    const productId = prodIdMatch[2];
+    const product = db.products.find(p => p.id === productId && p.familyId === familyId);
+    if (!product) return sendJson(res, 404, { error: 'Not found' });
+
+    if (req.method === 'PUT') {
+      try {
+        const body = await parseBody(req);
+        if (body.quantity !== undefined) product.current_quantity = Number(body.quantity);
+        if (body.minimum !== undefined) product.minimum_quantity = Number(body.minimum);
+        if (body.name) product.name = body.name;
+        if (body.categoryId) product.categoryId = body.categoryId;
+        save();
+        return sendJson(res, 200, product);
+      } catch (e) {
+        return sendJson(res, 400, { error: 'Invalid JSON' });
+      }
+    }
+    if (req.method === 'DELETE') {
+      db.products = db.products.filter(p => p.id !== productId);
+      save();
+      return sendJson(res, 204, {});
+    }
+  }
+
+  // Shopping lists manual
+  const listMatch = pathname.match(/^\/api\/families\/([^/]+)\/shopping-lists$/);
+  if (listMatch) {
+    const familyId = listMatch[1];
+    if (req.method === 'GET') {
+      const lists = db.shoppingLists.filter(l => l.familyId === familyId);
+      return sendJson(res, 200, lists);
+    }
+    if (req.method === 'POST') {
+      try {
+        const body = await parseBody(req);
+        if (!body.name || !Array.isArray(body.items)) {
+          return sendJson(res, 400, { error: 'Invalid data' });
+        }
+        const listId = generateId('sl_');
+        const items = body.items.map(it => ({
+          id: generateId('i_'),
+          productId: it.productId || null,
+          customName: it.customName || null,
+          quantity: Number(it.quantity) || 1,
+          unit: it.unit || 'unit',
+          is_purchased: false
+        }));
+        const list = { id: listId, familyId, name: body.name, createdAt: Date.now(), items };
+        db.shoppingLists.push(list);
+        save();
+        return sendJson(res, 201, list);
+      } catch (e) {
+        return sendJson(res, 400, { error: 'Invalid JSON' });
+      }
+    }
+  }
+
+  // Auto list
+  const autoListMatch = pathname.match(/^\/api\/families\/([^/]+)\/shopping-lists\/auto$/);
+  if (autoListMatch && req.method === 'POST') {
+    const familyId = autoListMatch[1];
+    const lowStock = db.products.filter(p => p.familyId === familyId && p.current_quantity <= p.minimum_quantity);
+    const listId = generateId('sl_');
+    const items = lowStock.map(p => ({
+      id: generateId('i_'),
+      productId: p.id,
+      quantity: Math.max(p.minimum_quantity - p.current_quantity, 1),
+      unit: p.unit,
+      is_purchased: false
+    }));
+    const list = { id: listId, familyId, name: 'Auto List', createdAt: Date.now(), items };
+    db.shoppingLists.push(list);
+    save();
+    return sendJson(res, 201, list);
+  }
+
+  sendJson(res, 404, { error: 'Not found' });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log('Server running on port', PORT);
+});


### PR DESCRIPTION
## Summary
- implement category management and manual shopping lists
- enhance HTML page with basic authentication and product forms
- document API routes for categories and lists

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68424cba350483338d249a2e1bf6341d